### PR TITLE
fix(elements/listbox): update listbox when the selection attribute is changed from the outside/template

### DIFF
--- a/src/assets/css/elements/button.css
+++ b/src/assets/css/elements/button.css
@@ -59,6 +59,7 @@ button[disabled]:focus {
   cursor: not-allowed;
   outline: none;
   box-shadow: none;
+  background-color: var(--color-bg);
 }
 
 .button-small {

--- a/src/behaviors/list/index.ts
+++ b/src/behaviors/list/index.ts
@@ -3,4 +3,4 @@ export * from './events.js';
 export * from './focus-list.js';
 export * from './list.js';
 export * from './types.js';
-
+export * from './utils.js';

--- a/src/behaviors/list/list.ts
+++ b/src/behaviors/list/list.ts
@@ -5,22 +5,7 @@ import { Behavior } from '../behavior';
 import { ListConfig, LIST_CONFIG_DEFAULT } from './config.js';
 import { ActivateEvent, SelectEvent } from './events.js';
 import { ListEntry, ListEntryLocator, ListEntryState, ListItem } from './types.js';
-
-const SELECTION_ATTRIBUTE_MAP = {
-    'checkbox': 'aria-checked',
-    'radio': 'aria-checked',
-    'menuitem': 'aria-selected',
-    'menuitemcheckbox': 'aria-checked',
-    'menuitemradio': 'aria-checked',
-    'option': 'aria-selected',
-    'tab': 'aria-selected',
-    'default': 'aria-selected',
-};
-
-const selectionAttribute = (item: HTMLElement | undefined): string => {
-
-    return SELECTION_ATTRIBUTE_MAP[item?.getAttribute('role') as keyof typeof SELECTION_ATTRIBUTE_MAP || 'default'];
-};
+import { isSelected, selectionAttribute } from './utils.js';
 
 const LIST_ID_GENERATOR = new IDGenerator('ui-list-');
 const ITEM_ID_GENERATOR = new IDGenerator('ui-list-item-');
@@ -163,7 +148,7 @@ export class ListBehavior<T extends ListItem = ListItem> extends Behavior {
             setAttribute(item, 'id', item.id || ITEM_ID_GENERATOR.getNext());
 
             // handle list items marked as selected
-            if (item.getAttribute(selectionAttribute(item)) === 'true') {
+            if (isSelected(item, this.config.itemRole)) {
 
                 this.setActive(item);
                 this.setSelected(item);
@@ -212,14 +197,14 @@ export class ListBehavior<T extends ListItem = ListItem> extends Behavior {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     protected markSelected (item: T | undefined, interactive = false): void {
 
-        item?.setAttribute(selectionAttribute(item), 'true');
+        item?.setAttribute(selectionAttribute(item, this.config.itemRole), 'true');
         item?.classList.add(this.config.classes.selected);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     protected markUnselected (item: T | undefined, interactive = false): void {
 
-        item?.setAttribute(selectionAttribute(item), 'false');
+        item?.setAttribute(selectionAttribute(item, this.config.itemRole), 'false');
         item?.classList.remove(this.config.classes.selected);
     }
 

--- a/src/behaviors/list/utils.ts
+++ b/src/behaviors/list/utils.ts
@@ -1,0 +1,21 @@
+export const SELECTION_ATTRIBUTE_MAP = {
+    'checkbox': 'aria-checked',
+    'radio': 'aria-checked',
+    'menuitem': 'aria-selected',
+    'menuitemcheckbox': 'aria-checked',
+    'menuitemradio': 'aria-checked',
+    'option': 'aria-selected',
+    'tab': 'aria-selected',
+    'default': 'aria-selected',
+};
+
+export const selectionAttribute = (item: HTMLElement | undefined, role?: string): string => {
+
+    return SELECTION_ATTRIBUTE_MAP[(item?.getAttribute('role') || role) as keyof typeof SELECTION_ATTRIBUTE_MAP || 'default']
+        ?? SELECTION_ATTRIBUTE_MAP['default'];
+};
+
+export const isSelected = (item: HTMLElement | undefined, role?: string): boolean => {
+
+    return item?.getAttribute(selectionAttribute(item, role)) === 'true';
+};


### PR DESCRIPTION
when templates are re-rendered, it should be possible to change the `aria-selected` or `aria-checked` attribute of a `ui-listitem` in the template and have the `ui-listbox` update its state accordingly;
export selection attribute helpers from the list behavior;
fix button `disabled` state styles