### PR TITLE
style: use full module specifier endings

### DIFF
--- a/demo/elements/panel-container/main.ts
+++ b/demo/elements/panel-container/main.ts
@@ -1,6 +1,6 @@
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { ListConfig } from '../../../src/behaviors/list/config.js';
+import { ListConfig } from '../../../src/behaviors/list/index.js';
 import { PanelChangeEvent, PanelDirection, PanelNavigationEvent } from '../../../src/elements/panel-container/index.js';
 import { dispatch } from '../../../src/utils/events/index.js';
 import '../../../src/elements/panel-container/panel-container.js';

--- a/src/elements/panel-container/events.ts
+++ b/src/elements/panel-container/events.ts
@@ -1,5 +1,5 @@
-import { ElementEvent, ElementEventDetail } from '../../utils/events';
-import { PanelDirection } from './types';
+import { ElementEvent, ElementEventDetail } from '../../utils/events/index.js';
+import { PanelDirection } from './types.js';
 
 export interface PanelNavigationEventDetail<T extends HTMLElement = HTMLElement> extends ElementEventDetail<T> {
     panel: number | PanelDirection;

--- a/src/elements/panel-container/index.ts
+++ b/src/elements/panel-container/index.ts
@@ -1,3 +1,3 @@
-export * from './events';
-export * from './types';
-export * from './panel-container';
+export * from './events.js';
+export * from './types.js';
+export * from './panel-container.js';

--- a/src/elements/panel-container/panel-container.ts
+++ b/src/elements/panel-container/panel-container.ts
@@ -1,12 +1,12 @@
 import { LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { CLASS_MAP, toggleVisibility } from '../../behaviors';
-import { ENTER, SPACE } from '../../utils';
-import { animationtask, cancelTask, TaskReference } from '../../utils/async';
-import { AnimationsDoneOptions, IDGenerator, isDisabled } from '../../utils/dom';
-import { cancel, EventManager } from '../../utils/events';
-import { PanelChangeEvent, PanelNavigationEvent } from './events';
-import { PanelDirection } from './types';
+import { CLASS_MAP, toggleVisibility } from '../../behaviors/index.js';
+import { animationtask, cancelTask, TaskReference } from '../../utils/async/index.js';
+import { AnimationsDoneOptions, IDGenerator, isDisabled } from '../../utils/dom/index.js';
+import { cancel, EventManager } from '../../utils/events/index.js';
+import { ENTER, SPACE } from '../../utils/index.js';
+import { PanelChangeEvent, PanelNavigationEvent } from './events.js';
+import { PanelDirection } from './types.js';
 
 /*
  * ID generators for the trigger and panel elements

--- a/src/elements/tabs/index.ts
+++ b/src/elements/tabs/index.ts
@@ -1,1 +1,1 @@
-export * from './tabs';
+export * from './tabs.js';

--- a/src/elements/tabs/tabs.ts
+++ b/src/elements/tabs/tabs.ts
@@ -1,9 +1,9 @@
 import { PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { FocusListBehavior, ListConfig, LIST_CONFIG_TABS, SelectEvent } from '../../behaviors/list';
-import { IDGenerator } from '../../utils/dom';
-import { cancel } from '../../utils/events';
-import { PanelContainerElement } from '../panel-container';
+import { FocusListBehavior, ListConfig, LIST_CONFIG_TABS, SelectEvent } from '../../behaviors/list/index.js';
+import { IDGenerator } from '../../utils/dom/index.js';
+import { cancel } from '../../utils/events/index.js';
+import { PanelContainerElement } from '../panel-container/index.js';
 
 const TRIGGER_ID_GENERATOR = new IDGenerator('ui-tabs-trigger-');
 const PANEL_ID_GENERATOR = new IDGenerator('ui-tabs-panel-');

--- a/src/elements/wizard/index.ts
+++ b/src/elements/wizard/index.ts
@@ -1,1 +1,1 @@
-export * from './wizard';
+export * from './wizard.js';

--- a/src/elements/wizard/wizard.ts
+++ b/src/elements/wizard/wizard.ts
@@ -1,6 +1,6 @@
 import { customElement } from 'lit/decorators.js';
-import { IDGenerator } from '../../utils/dom';
-import { PanelContainerElement } from '../panel-container';
+import { IDGenerator } from '../../utils/dom/index.js';
+import { PanelContainerElement } from '../panel-container/index.js';
 
 const TRIGGER_ID_GENERATOR = new IDGenerator('ui-wizard-trigger-');
 const PANEL_ID_GENERATOR = new IDGenerator('ui-wizard-panel-');


### PR DESCRIPTION
use `.js` extension for module imports to allow using `@swivel-finance/ui` package without using a bundler (plain ES module imports)