### PR TITLE
feat: add expanded/collapsed classes to collapsible

### DIFF
--- a/src/behaviors/utils/class-map.ts
+++ b/src/behaviors/utils/class-map.ts
@@ -9,6 +9,8 @@ export const CLASS_MAP = {
     animateOut: 'ui-animate-out',
     forward: 'ui-forward',
     backward: 'ui-backward',
+    expanded: 'ui-expanded',
+    collapsed: 'ui-collapsed',
     horizontal: 'ui-horizontal',
     vertical: 'ui-vertical',
     overlay: 'ui-overlay',

--- a/src/elements/collapsible/collapsible.ts
+++ b/src/elements/collapsible/collapsible.ts
@@ -155,6 +155,10 @@ export class CollapsibleElement extends LitElement {
 
             this.triggerElement?.setAttribute('aria-expanded', String(this.expanded));
         }
+
+        // add a class indicating the state to the root element
+        this.classList.add(this.expanded ? CLASS_MAP.expanded : CLASS_MAP.collapsed);
+        this.classList.remove(this.expanded ? CLASS_MAP.collapsed : CLASS_MAP.expanded);
     }
 
     protected createRenderRoot (): Element | ShadowRoot {


### PR DESCRIPTION
add expanded/collapsed classes to the root collapsible element to help styling in browsers which don't support the css `:has()` selector