### PR TITLE
fix(tooltip-trigger): keep tooltips open when hovered

### DIFF
--- a/src/behaviors/position/position.ts
+++ b/src/behaviors/position/position.ts
@@ -48,7 +48,12 @@ export class PositionBehavior extends Behavior {
 
         this._config = value;
 
-        if (this.hasAttached) this.initialize();
+        if (this.hasAttached) {
+
+            this.initialize();
+
+            void this.requestUpdate();
+        }
     }
 
     constructor (config?: Partial<PositionConfig>) {


### PR DESCRIPTION
listen to hover events from the tooltip overlay to prevent tooltips from closing when the trigger loses hover/focus state;
ensure the OverlayBehavior updates if its configuration changes during runtime;