### PR TITLE
fix: overlay detachment when using animations

### DIFF
--- a/demo/behaviors/overlay/main.css
+++ b/demo/behaviors/overlay/main.css
@@ -78,6 +78,10 @@ ui-backdrop.ui-visible {
   max-height: calc(100vh - var(--line-height) * 2);
 }
 
+.overlay[hidden] {
+  display: none;
+}
+
 .overlay.ui-invisible {
   /* the !important is there when used with the centered-position-strategy */
   transform: translateY(-50vw) !important;

--- a/demo/behaviors/overlay/main.ts
+++ b/demo/behaviors/overlay/main.ts
@@ -85,8 +85,8 @@ const initOverlay = () => {
 
 const detachOverlay = () => {
 
-    triggerBehavior.detach();
     overlayBehavior.detach();
+    triggerBehavior.detach();
 };
 
 const initDetachDialog = () => {

--- a/src/behaviors/overlay/overlay.ts
+++ b/src/behaviors/overlay/overlay.ts
@@ -203,10 +203,14 @@ export class OverlayBehavior extends Behavior {
 
         const isVisible = toggleVisibility(element, false, this.trigger?.element, this.config.animated && !detaching, this.config.classes, this.config.animationOptions);
 
-        await isVisible;
+        // skip awaiting animations when detaching - in this case we hide the overlay synchronously
+        if (this.config.animated && !detaching) {
 
-        // if overlay was shown in the meantime, finish here
-        if (!this.hidden) return;
+            await isVisible;
+
+            // if overlay was shown in the meantime, finish here
+            if (!this.hidden) return;
+        }
 
         this.config.positionBehavior?.detach();
 

--- a/src/elements/dialog/dialog.ts
+++ b/src/elements/dialog/dialog.ts
@@ -182,8 +182,8 @@ export class DialogElement<T = unknown> extends LitElement {
 
     protected detachBehaviors (): void {
 
-        this.triggerBehavior?.detach();
         this.overlayBehavior?.detach();
+        this.triggerBehavior?.detach();
     }
 
     protected dispatchResult (result?: T): void {

--- a/src/elements/popup/popup.ts
+++ b/src/elements/popup/popup.ts
@@ -214,7 +214,7 @@ export class PopupElement extends LitElement {
 
     protected detachBehaviors (): void {
 
-        this.triggerBehavior?.detach();
         this.overlayBehavior?.detach();
+        this.triggerBehavior?.detach();
     }
 }

--- a/src/elements/tooltip/tooltip.ts
+++ b/src/elements/tooltip/tooltip.ts
@@ -27,11 +27,11 @@ export class TooltipElement extends LitElement {
 
         if (this.overlayBehavior.moving) return;
 
+        this.overlayBehavior.detach();
+
         this.triggerBehaviors.forEach(behavior => behavior.detach());
 
         this.triggerBehaviors.clear();
-
-        this.overlayBehavior.detach();
     }
 
     /**


### PR DESCRIPTION
ensure the overlay is properly moved back into place and hidden when detached;
skip awaiting animations during detachment;
fix the order of behavior detachments for popup, dialog and tooltip elements;